### PR TITLE
FOLIO-3637: postgresql 42.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.5.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Upgrade postgresql (JDBC driver) from 42.3.3 to 42.5.0. This fixes SQL Injection:
https://nvd.nist.gov/vuln/detail/CVE-2022-31197

42.3 and 42.4 have reached end-of-life and are no longer supported:
https://jdbc.postgresql.org/download/