### PR TITLE
FOLIO-3639: Spring Boot 2.7.5, Jackson 2.14.0, snakeyaml 1.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,26 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>2.6.7</spring-boot.version>
+    <spring-boot.version>2.7.5</spring-boot.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.14.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.33</version>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -41,6 +56,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>


### PR DESCRIPTION
Upgrade Spring Boot from 2.6.7 to 2.7.5.

End of support for Open Source Spring Boot 2.6 is 2022-11-18:
https://spring.io/projects/spring-boot#support

Upgrading Spring Boot upgrades spring-beans from 5.3.19 to 5.3.23 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-22970

Upgrading Spring Boot upgrades tomcat-embed-core from 9.0.62 to 9.0.68 fixing HTTP Request Smuggling: 
https://nvd.nist.gov/vuln/detail/CVE-2022-42252

Upgrade Jackson from 2.13.2.1 (transitive version from Spring Boot) to 2.14.0 fixing Denial of Service (DoS): 
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade snakeyaml from 1.29 (transitive version from Spring Boot) to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow: 
https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752