### PR TITLE
FOLIO-3724: spring-module-core: Spring Boot 2.7.9, PostgreSQL 42.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>2.7.5</spring-boot.version>
+    <spring-boot.version>2.7.9</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.1</version>
+        <version>42.5.4</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Upgrade Spring Boot from 2.7.5 to 2.7.9. This indirectly upgrades tomcat-embed-core from 9.0.68 to 9.0.71 fixing Denial of Service (DoS) and Improper Input Validation:

https://nvd.nist.gov/vuln/detail/CVE-2023-24998
https://nvd.nist.gov/vuln/detail/CVE-2022-45143

Also upgrade the JDBC PostgreSQL client from 42.5.1 to 42.5.4 to make sure socket is closed if an exception is thrown in createSocket.

https://jdbc.postgresql.org/changelogs/2023-01-31-42.5.2-release/