### PR TITLE
FOLIO-3912: Java 17, Spring Boot 3, Hibernate 6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spring Module Core
 
-Copyright (C) 2018-2022 The Open Library Foundation
+Copyright (C) 2018-2023 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0.
 See the file ["LICENSE"](LICENSE) for more information.

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-c3p0</artifactId>
     </dependency>
 

--- a/domain/src/main/java/org/folio/spring/controller/RamlsController.java
+++ b/domain/src/main/java/org/folio/spring/controller/RamlsController.java
@@ -3,7 +3,7 @@ package org.folio.spring.controller;
 import java.io.IOException;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.folio.spring.controller.exception.SchemaIOException;
 import org.folio.spring.service.RamlsService;

--- a/domain/src/main/java/org/folio/spring/domain/generator/CustomUUIDGenerator.java
+++ b/domain/src/main/java/org/folio/spring/domain/generator/CustomUUIDGenerator.java
@@ -9,8 +9,9 @@ public class CustomUUIDGenerator extends UUIDGenerator {
 
   @Override
   public Serializable generate(SharedSessionContractImplementor session, Object object) {
-    Serializable id = session.getEntityPersister(null, object).getClassMetadata().getIdentifier(object, session);
-    return id != null ? id : super.generate(session, object);
+    Serializable id =
+        (Serializable) session.getEntityPersister(null, object).getClassMetadata().getIdentifier(object, session);
+    return id != null ? id : (Serializable) super.generate(session, object);
   }
 
 }

--- a/domain/src/main/java/org/folio/spring/domain/generator/EntityJsonSchemaGenerator.java
+++ b/domain/src/main/java/org/folio/spring/domain/generator/EntityJsonSchemaGenerator.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 
 import org.folio.spring.controller.exception.SchemaIOException;
 import org.folio.spring.controller.exception.SchemaNotFoundException;

--- a/domain/src/main/java/org/folio/spring/domain/model/AbstractBaseEntity.java
+++ b/domain/src/main/java/org/folio/spring/domain/model/AbstractBaseEntity.java
@@ -1,9 +1,9 @@
 package org.folio.spring.domain.model;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 import org.hibernate.annotations.GenericGenerator;
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,24 +27,16 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>2.7.10</spring-boot.version>
+    <spring-boot.version>3.1.4</spring-boot.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
 
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.14.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.33</version>
+        <version>2.2</version>
       </dependency>
 
       <dependency>
@@ -56,29 +48,21 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.17.2</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.0</version>
       </dependency>
 
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.1.210</version>
+        <version>2.2.224</version>
       </dependency>
 
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.4</version>
+        <version>42.6.0</version>
       </dependency>
 
     </dependencies>
@@ -96,9 +80,9 @@
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.11.0</version>
           <configuration>
-            <release>11</release>
+            <release>17</release>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>
@@ -106,7 +90,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.1</version>
           <configuration>
             <delimiters>
               <delimiter>@</delimiter>
@@ -142,7 +126,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.1.2</version>
         </plugin>
 
       </plugins>
@@ -152,7 +136,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -166,11 +150,11 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>deploy</phase>
+            <phase>verify</phase>
             <goals>
               <goal>jar</goal>
             </goals>
@@ -180,7 +164,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -39,7 +39,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-ant</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-c3p0</artifactId>
     </dependency>
 

--- a/tenant/src/main/java/org/folio/spring/tenant/config/HibernateMultiTenantConfig.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/config/HibernateMultiTenantConfig.java
@@ -1,7 +1,5 @@
 package org.folio.spring.tenant.config;
 
-import static org.hibernate.MultiTenancyStrategy.SCHEMA;
-import static org.hibernate.cfg.AvailableSettings.MULTI_TENANT;
 import static org.hibernate.cfg.AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER;
 import static org.hibernate.cfg.AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER;
 
@@ -40,7 +38,6 @@ public class HibernateMultiTenantConfig {
   // @formatter:on
     Map<String, Object> properties = new HashMap<>();
     properties.putAll(jpaProperties.getProperties());
-    properties.put(MULTI_TENANT, SCHEMA);
     properties.put(MULTI_TENANT_CONNECTION_PROVIDER, multiTenantConnectionProvider);
     properties.put(MULTI_TENANT_IDENTIFIER_RESOLVER, currentTenantIdentifierResolver);
     LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();

--- a/tenant/src/main/java/org/folio/spring/tenant/hibernate/HibernateSchemaService.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/hibernate/HibernateSchemaService.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -214,7 +214,8 @@ public class HibernateSchemaService implements InitializingBean {
   }
 
   private MetadataImplementor buildMetadata(Map<String, String> settings) {
-    StandardServiceRegistry registry = new StandardServiceRegistryBuilder().applySettings(settings).build();
+    Map<String, Object> settings2 = Map.copyOf(settings);
+    StandardServiceRegistry registry = new StandardServiceRegistryBuilder().applySettings(settings2).build();
     MetadataSources sources = addEntities(new MetadataSources(registry));
     return (MetadataImplementor) sources.getMetadataBuilder().build();
   }

--- a/tenant/src/main/java/org/folio/spring/tenant/hibernate/HibernateTenantIdentifierResolver.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/hibernate/HibernateTenantIdentifierResolver.java
@@ -2,8 +2,8 @@ package org.folio.spring.tenant.hibernate;
 
 import java.util.Optional;
 
-import javax.annotation.PreDestroy;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.annotation.PreDestroy;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.folio.spring.tenant.exception.NoTenantHeaderException;
 import org.folio.spring.tenant.properties.TenantProperties;

--- a/tenant/src/main/java/org/folio/spring/tenant/service/SqlTemplateService.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/service/SqlTemplateService.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
-import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Service
 public class SqlTemplateService {

--- a/tenant/src/test/java/org/folio/spring/tenant/TenantContextHelper.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/TenantContextHelper.java
@@ -1,6 +1,6 @@
 package org.folio.spring.tenant;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mock.web.MockHttpServletRequest;

--- a/tenant/src/test/java/org/folio/spring/tenant/service/SchemaServiceTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/service/SchemaServiceTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.folio.spring.tenant.properties.BuildInfoProperties;
+import org.hibernate.boot.model.source.spi.MultiTenancySource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/web/src/main/java/org/folio/spring/converter/ObjectPlainTextConverter.java
+++ b/web/src/main/java/org/folio/spring/converter/ObjectPlainTextConverter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;

--- a/web/src/main/java/org/folio/spring/model/response/Error.java
+++ b/web/src/main/java/org/folio/spring/model/response/Error.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/web/src/main/java/org/folio/spring/model/response/Parameter.java
+++ b/web/src/main/java/org/folio/spring/model/response/Parameter.java
@@ -3,7 +3,7 @@ package org.folio.spring.model.response;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/web/src/main/java/org/folio/spring/model/response/ResponseErrors.java
+++ b/web/src/main/java/org/folio/spring/model/response/ResponseErrors.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/web/src/main/java/org/folio/spring/service/HttpService.java
+++ b/web/src/main/java/org/folio/spring/service/HttpService.java
@@ -3,10 +3,9 @@ package org.folio.spring.service;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,10 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;


### PR DESCRIPTION
Upgrade Java/JDK from 11 to 17.

Upgrade Spring Boot from 2 to 3.

The Spring Boot upgrade automatically upgrades Hibernate from 5 to 6.

Upgrade Snakeyaml from 1.33 to 2.2.

This fixes multiple vulnerabilities in the dependencies:
* thymeleaf - Sandbox Bypass - https://nvd.nist.gov/vuln/detail/CVE-2023-38286
* spring-boot-autoconfigure - Denial of Service (DoS) - https://nvd.nist.gov/vuln/detail/CVE-2023-20883
* snakeyaml - Arbitrary Code Execution - https://nvd.nist.gov/vuln/detail/CVE-2022-1471
* spring-expression - Allocation of Resources Without Limits or Throttling - https://nvd.nist.gov/vuln/detail/CVE-2023-20863
* tomcat-embed-core - Denial of Service (DoS) - https://nvd.nist.gov/vuln/detail/CVE-2023-28709

Upgrading guides:
https://wiki.folio.org/display/TC/JDK+17+and+Java+17
https://wiki.folio.org/display/FOLIJET/Migration+to+Spring+Boot+v3.0.0+How+to
https://github.com/hibernate/hibernate-orm/blob/6.0/migration-guide.adoc#multitenancy-simplification
https://wiki.folio.org/display/SEC/SnakeYaml+SafeConstructor