### PR TITLE
FOLIO-3915: spring-boot-starter-web 3.1.5 fixing tomcat DoS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>3.1.4</spring-boot.version>
+    <spring-boot.version>3.1.5</spring-boot.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Upgrade spring-boot-starter-web from 3.1.4 to 3.1.5.

This indirectly upgrades tomcat-embed-core from 10.1.13 to 10.1.14 fixing these security vulnerabilities:

* Request smuggling https://nvd.nist.gov/vuln/detail/CVE-2023-45648
* Denial of Service https://nvd.nist.gov/vuln/detail/CVE-2023-44487
* Information Disclosure https://nvd.nist.gov/vuln/detail/CVE-2023-42795