### PR TITLE
Upgrade deps for Quesnelia: Spring Boot, commons-io, postgresql, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -45,15 +45,9 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>2.2</version>
-      </dependency>
-
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>2.15.1</version>
       </dependency>
 
       <dependency>
@@ -65,7 +59,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.6.0</version>
+        <version>42.7.3</version>
       </dependency>
 
     </dependencies>
@@ -87,7 +81,7 @@
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <configuration>
             <release>17</release>
             <encoding>UTF-8</encoding>


### PR DESCRIPTION
Upgrade all dependencies to supported versions.

Upgrade spring-boot-starter-parent from 3.2.2 to 3.2.3.

The spring-boot-starter-parent upgrade indirectly upgrades tomcat-embed-websocket from 10.1.18 to 10.1.19 fixing Denial of Service (DoS): https://www.cve.org/CVERecord?id=CVE-2024-23672

The spring-boot-starter-parent upgrade indirectly upgrades spring-web from 10.1.18 to 10.1.19 fixing Denial of Service (DoS) and Open Redirect: https://www.cve.org/CVERecord?id=CVE-2024-24549 , https://www.cve.org/CVERecord?id=CVE-2024-22243

Upgrade commons-io from 2.14.0 to 2.15.1.

Upgrade postgresql from 42.6.0 to 42.7.3.

Upgrade maven-compiler-plugin from 3.11.0 to 3.13.0.

No longer pin snakeyaml to 2.2 because spring-boot-starter-parent provides snakeyaml 2.2.