### PR TITLE
SPRNGCORE-1: Add option to re-create the database and update the settings.

### DIFF
--- a/tenant/src/main/java/org/folio/spring/tenant/properties/TenantProperties.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/properties/TenantProperties.java
@@ -21,6 +21,8 @@ public class TenantProperties implements Serializable {
 
   private boolean initializeDefaultTenant = false;
 
+  private boolean recreateDefaultTenant = false;
+
   private List<String> domainPackages = new ArrayList<>();
 
   private List<String> schemaScripts = new ArrayList<>();
@@ -55,6 +57,14 @@ public class TenantProperties implements Serializable {
 
   public void setInitializeDefaultTenant(boolean initializeDefaultTenant) {
     this.initializeDefaultTenant = initializeDefaultTenant;
+  }
+
+  public boolean isRecreateDefaultTenant() {
+    return recreateDefaultTenant;
+  }
+
+  public void setRecreateDefaultTenant(boolean recreateDefaultTenant) {
+    this.recreateDefaultTenant = recreateDefaultTenant;
   }
 
   public List<String> getDomainPackages() {

--- a/tenant/src/test/java/org/folio/spring/tenant/properties/TenantPropertiesTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/properties/TenantPropertiesTest.java
@@ -1,0 +1,136 @@
+package org.folio.spring.tenant.properties;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TenantPropertiesTest {
+
+  private TenantProperties tenantProperties;
+
+  private List<String> domainPackages;
+
+  private List<String> schemaScripts;
+
+  @BeforeEach
+  void beforeEach() {
+    tenantProperties = new TenantProperties();
+    domainPackages = new ArrayList<>();
+    schemaScripts = new ArrayList<>();
+
+    domainPackages.add(VALUE);
+    schemaScripts.add(VALUE);
+  }
+
+  @Test
+  void getHeaderNameWorksTest() {
+    setField(tenantProperties, "headerName", VALUE);
+
+    assertEquals(VALUE, tenantProperties.getHeaderName());
+  }
+
+  @Test
+  void setHeaderNameWorksTest() {
+    setField(tenantProperties, "headerName", null);
+
+    tenantProperties.setHeaderName(VALUE);
+    assertEquals(VALUE, getField(tenantProperties, "headerName"));
+  }
+
+  @Test
+  void isForceTenantWorksTest() {
+    setField(tenantProperties, "forceTenant", true);
+
+    assertEquals(true, tenantProperties.isForceTenant());
+  }
+
+  @Test
+  void setForceTenantWorksTest() {
+    setField(tenantProperties, "forceTenant", false);
+
+    tenantProperties.setForceTenant(true);
+    assertEquals(true, getField(tenantProperties, "forceTenant"));
+  }
+
+  @Test
+  void getDefaultTenantWorksTest() {
+    setField(tenantProperties, "defaultTenant", VALUE);
+
+    assertEquals(VALUE, tenantProperties.getDefaultTenant());
+  }
+
+  @Test
+  void setDefaultTenantWorksTest() {
+    setField(tenantProperties, "defaultTenant", null);
+
+    tenantProperties.setDefaultTenant(VALUE);
+    assertEquals(VALUE, getField(tenantProperties, "defaultTenant"));
+  }
+
+  @Test
+  void isInitializeDefaultTenantWorksTest() {
+    setField(tenantProperties, "initializeDefaultTenant", true);
+
+    assertEquals(true, tenantProperties.isInitializeDefaultTenant());
+  }
+
+  @Test
+  void setInitializeDefaultTenantWorksTest() {
+    setField(tenantProperties, "initializeDefaultTenant", false);
+
+    tenantProperties.setInitializeDefaultTenant(true);
+    assertEquals(true, getField(tenantProperties, "initializeDefaultTenant"));
+  }
+
+  @Test
+  void isRecreateDefaultTenantWorksTest() {
+    setField(tenantProperties, "recreateDefaultTenant", true);
+
+    assertEquals(true, tenantProperties.isRecreateDefaultTenant());
+  }
+
+  @Test
+  void setRecreateDefaultTenantWorksTest() {
+    setField(tenantProperties, "recreateDefaultTenant", false);
+
+    tenantProperties.setRecreateDefaultTenant(true);
+    assertEquals(true, getField(tenantProperties, "recreateDefaultTenant"));
+  }
+
+  @Test
+  void getDomainPackagesWorksTest() {
+    setField(tenantProperties, "domainPackages", domainPackages);
+
+    assertEquals(domainPackages, tenantProperties.getDomainPackages());
+  }
+
+  @Test
+  void setDomainPackagesWorksTest() {
+    setField(tenantProperties, "domainPackages", null);
+
+    tenantProperties.setDomainPackages(domainPackages);
+    assertEquals(domainPackages, getField(tenantProperties, "domainPackages"));
+  }
+
+  @Test
+  void getSchemaScriptsWorksTest() {
+    setField(tenantProperties, "schemaScripts", schemaScripts);
+
+    assertEquals(schemaScripts, tenantProperties.getSchemaScripts());
+  }
+
+  @Test
+  void setSchemaScriptsWorksTest() {
+    setField(tenantProperties, "schemaScripts", null);
+
+    tenantProperties.setSchemaScripts(schemaScripts);
+    assertEquals(schemaScripts, getField(tenantProperties, "schemaScripts"));
+  }
+
+}


### PR DESCRIPTION
[SPRNGCORE-1](https://folio-org.atlassian.net/browse/SPRNGCORE-1)

This adds a new configuration option called `tenant.recreate-default-tenant` that accepts either `true` or `false`.
This only does anything when `initialize-default-tenant` is set to `true`.
When `true` and the database schema already exists, then this will drop the schema/tenant database data.
Then a clean tenant database schema and data will be created.

The default setting for this is `false` to prevent unintended database destruction.

The new environment variable is `TENANT_RECREATEDEFAULTTENANT`, such as `TENANT_RECREATEDEFAULTTENANT=true`.

Deployments may no longer need to manually drop and create the schema and can now just set both `TENANT_RECREATEDEFAULTTENANT` and `TENANT_INITIALIZEDEFAULTENANT` to `true` to re-create the database.

Modules utilizing this project, such as `mod-camunda` and `mod-workflow` should provide updates to their `ModuleDescriptor-template.json` and possibly their `application.yaml` files.

Additional related changes:
- Bring in the `ddl-auto` settings and default it to `none`.
- Maintain the `hibernate.hbm2ddl.auto` but have it utilize the `ddl-auto` setting.
- Have the `hibernate.jdbc.lob.non_contextual_creation` no longer be hard-coded and instead pull in the setting from the `application.yaml` or the environment variable.
- Add the `hibernate.open-in-view` and make it configurable to match the common `application.yaml` settings.
- Have the `hibernate.show-sql` no longer be hard-coded and instead pull in the setting from the `application.yaml` or the environment variable.
- The `dialect` directly on the `hibernate` settings has been deprecated but this assignment is being preserved for now.
- Pull in the newer alternative for `dialect` (`database-platform`) and provide that along side the `dialect` (hopefully this makes the module more forward compatible).