### PR TITLE
SPRNGCORE-6: Upgrade to Spring-boot 3.4.2 and springdoc 2.8.4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 target/
 .settings/
 !.mvn/wrapper/maven-wrapper.jar
+/target_test-classes/
 
 ### STS ###
 .apt_generated

--- a/domain/src/test/java/org/folio/spring/domain/controller/JsonSchemasControllerTest.java
+++ b/domain/src/test/java/org/folio/spring/domain/controller/JsonSchemasControllerTest.java
@@ -53,9 +53,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -71,7 +71,7 @@ class JsonSchemasControllerTest {
   @Autowired
   private MockMvc mvc;
 
-  @MockBean
+  @MockitoBean
   private JsonSchemasService jsonSchemasService;
 
   @ParameterizedTest

--- a/domain/src/test/java/org/folio/spring/domain/controller/RamlsControllerTest.java
+++ b/domain/src/test/java/org/folio/spring/domain/controller/RamlsControllerTest.java
@@ -53,9 +53,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -71,7 +71,7 @@ class RamlsControllerTest {
   @Autowired
   private MockMvc mvc;
 
-  @MockBean
+  @MockitoBean
   private RamlsService ramlsService;
 
   @ParameterizedTest

--- a/domain/src/test/java/org/folio/spring/domain/generator/FolioUUIDGeneratorTest.java
+++ b/domain/src/test/java/org/folio/spring/domain/generator/FolioUUIDGeneratorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.enhanced.AccessCallback;
 import org.hibernate.id.enhanced.DatabaseStructure;
 import org.hibernate.id.enhanced.Optimizer;
@@ -51,7 +52,7 @@ class FolioUUIDGeneratorTest {
 
   @Test
   void generateWorksTest() {
-    when(persister.getIdentifier(any(), any())).thenReturn(UUID);
+    when(persister.getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(UUID);
 
     Object result = folioUUIDGenerator.generate(session, folioUUIDGenerator);
 
@@ -60,7 +61,7 @@ class FolioUUIDGeneratorTest {
 
   @Test
   void generateWorksWithNullIdentifierTest() {
-    when(persister.getIdentifier(any(), any())).thenReturn(null);
+    when(persister.getIdentifier(any(), any(SharedSessionContractImplementor.class))).thenReturn(null);
     when(databaseStructure.buildCallback(any())).thenReturn(accessCallback);
     when(optimizer.generate(any())).thenReturn(JSON_OBJECT);
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.7</version>
+    <version>3.4.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
-    <springdoc.version>2.3.0</springdoc.version>
+    <springdoc.version>2.8.4</springdoc.version>
   </properties>
 
   <dependencyManagement>

--- a/tenant/src/test/java/org/folio/spring/tenant/controller/TenantControllerTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/controller/TenantControllerTest.java
@@ -42,9 +42,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -60,7 +60,7 @@ class TenantControllerTest {
   @Autowired
   private MockMvc mvc;
 
-  @MockBean
+  @MockitoBean
   private HibernateSchemaService hibernateSchemaService;
 
   @ParameterizedTest

--- a/web/src/main/java/org/folio/spring/web/service/HttpService.java
+++ b/web/src/main/java/org/folio/spring/web/service/HttpService.java
@@ -44,8 +44,8 @@ public class HttpService {
     messageConverters.add(new ObjectPlainTextConverter(StandardCharsets.UTF_8));
 
     this.restTemplate = restTemplateBuilder
-        .setConnectTimeout(Duration.ofSeconds(connectionTimeout))
-        .setReadTimeout(Duration.ofSeconds(readTimeout))
+        .connectTimeout(Duration.ofSeconds(connectionTimeout))
+        .readTimeout(Duration.ofSeconds(readTimeout))
         .additionalMessageConverters(messageConverters)
         .build();
   }


### PR DESCRIPTION
Resolves: [SPRNGCORE-6](https://folio-org.atlassian.net/browse/SPRNGCORE-6)

Address newly deprecated code issues.

Address ambiguous `any()` issue that now appears and breaks tests.

The `@MockBean` is no longer available and we must instead use `@MockitoBean`.
see: https://github.com/spring-projects/spring-framework/issues/29917#issuecomment-1987282462
see: https://github.com/spring-projects/spring-framework/issues/33925
see: https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-mockitobean.html

_Note: This is as a draft until such time `mod-camunda` and `mod-workflow` can be tested and fixed for regressions under this change._

