### PR TITLE
Upgrade to spring-boot 3.4.8 and springdoc 2.8.9.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.5</version>
+    <version>3.4.8</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
-    <springdoc.version>2.8.5</springdoc.version>
+    <springdoc.version>2.8.9</springdoc.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This should bring dependencies up to date and fix any CVEs in the dependencies resolved in the newer versions.