### PR TITLE
SPRNGCORE-18: Change additional overlooked version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
+    <spring-module-core.version>2.2.0-SNAPSHOT</spring-module-core.version>
     <springdoc.version>3.0.3</springdoc.version>
   </properties>
 


### PR DESCRIPTION
Part of resolving: [SPRNGCORE-18](https://folio-org.atlassian.net/browse/SPRNGCORE-18) .

I missed the spot where the property also has to be set to `2.2.0-SNAPSHOT` for `spring-module-core.version`.