### PR TITLE
SPRNGCORE-27: Upgrade commons-io 2.22.0, org.postgresql 42.7.11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
       </dependency>
 
       <dependency>
@@ -58,7 +58,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.8</version>
+        <version>42.7.11</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Resolves [SPRNGCORE-27](https://folio-org.atlassian.net/browse/SPRNGCORE-27) .

Other versions were upgraded here: https://github.com/folio-org/spring-module-core/pull/99 , such as spring-boot 3.4.13.