### PR TITLE
SPRNGCORE-18: Properly switch to Jackson 3.

### DIFF
--- a/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
+++ b/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
@@ -1,15 +1,16 @@
 package org.folio.spring.domain.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.MapperFeature;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
- * Jackson Confoguration.
+ * Jackson Configuration.
  */
 @Configuration
 public class JacksonConfiguration {
@@ -22,11 +23,19 @@ public class JacksonConfiguration {
   }
 
   @Bean
-  ObjectMapper objectMapper() {
-    return JsonMapper.builder()
-      .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
-      .enable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+  JsonMapper jsonMapper() {
+    return JsonMapper
+      .builderWithJackson2Defaults()
+      .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES, true)
+      .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+      .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true)
+      .changeDefaultPropertyInclusion(incl -> incl
+        .withValueInclusion(JsonInclude.Include.NON_NULL)
+        .withContentInclusion(JsonInclude.Include.NON_NULL)
+      )
+      .findAndAddModules()
       .build();
   }
 }

--- a/domain/src/main/java/org/folio/spring/domain/controller/JsonSchemasController.java
+++ b/domain/src/main/java/org/folio/spring/domain/controller/JsonSchemasController.java
@@ -48,9 +48,9 @@ public class JsonSchemasController {
    */
   @GetMapping
   public ResponseEntity<Object> getSchemas(
-    @RequestParam(value = "path", required = false) Optional<String> path,
+    @RequestParam(required = false) Optional<String> path,
     @RequestHeader(value = "x-okapi-url", required = true) String okapiUrl,
-    @RequestHeader(value = "accept", required = false) String accept
+    @RequestHeader(required = false) String accept
   ) {
     try {
       if (path.isPresent()) {

--- a/domain/src/main/java/org/folio/spring/domain/controller/RamlsController.java
+++ b/domain/src/main/java/org/folio/spring/domain/controller/RamlsController.java
@@ -51,9 +51,9 @@ public class RamlsController {
   @GetMapping
   public ResponseEntity<Object> getRamls(
     HttpServletResponse response,
-    @RequestParam(value = "path", required = false) Optional<String> path,
+    @RequestParam(required = false) Optional<String> path,
     @RequestHeader(value = "x-okapi-url", required = true) String okapiUrl,
-    @RequestHeader(value = "accept", required = false) String accept
+    @RequestHeader(required = false) String accept
   ) {
     try {
       if (path.isPresent()) {

--- a/domain/src/main/java/org/folio/spring/domain/service/JsonSchemasService.java
+++ b/domain/src/main/java/org/folio/spring/domain/service/JsonSchemasService.java
@@ -10,7 +10,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * JSON Schema Service.
@@ -25,7 +25,7 @@ public class JsonSchemasService {
 
   private final ResourcePatternResolver resolver;
 
-  private final ObjectMapper mapper;
+  private final JsonMapper mapper;
 
   /**
    * Initializer.
@@ -33,7 +33,7 @@ public class JsonSchemasService {
    * @param resolver The pattern resolver.
    * @param mapper The object mapper.
    */
-  public JsonSchemasService(ResourcePatternResolver resolver, ObjectMapper mapper) {
+  public JsonSchemasService(ResourcePatternResolver resolver, JsonMapper mapper) {
       this.resolver = resolver;
       this.mapper = mapper;
   }

--- a/domain/src/test/java/org/folio/spring/domain/service/JsonSchemasServiceTest.java
+++ b/domain/src/test/java/org/folio/spring/domain/service/JsonSchemasServiceTest.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.folio.spring.domain.controller.exception.SchemaNotFoundException;
+import org.folio.spring.test.helper.MapperHelper;
 import org.folio.spring.test.mock.MockMvcConstant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +27,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(SpringExtension.class)
@@ -42,11 +42,11 @@ class JsonSchemasServiceTest {
   @InjectMocks
   private JsonSchemasService jsonSchemasService;
 
-  private ObjectMapper mapper;
+  private JsonMapper mapper;
 
   @BeforeEach
   void beforeEach() {
-    mapper = JsonMapper.builder().build();
+    mapper = MapperHelper.build();
 
     jsonSchemasService = new JsonSchemasService(resolver, mapper);
   }
@@ -78,7 +78,7 @@ class JsonSchemasServiceTest {
   }
 
   @Test
-  void getSchemaByPathThrowsSchemaNotFoundExceptionTest() throws IOException {
+  void getSchemaByPathThrowsSchemaNotFoundExceptionTest() {
     when(resource.exists()).thenReturn(false);
     when(resolver.getResource(anyString())).thenReturn(resource);
 

--- a/messaging/src/test/java/org/folio/spring/messaging/model/EventTest.java
+++ b/messaging/src/test/java/org/folio/spring/messaging/model/EventTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.folio.spring.test.helper.MapperHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,11 +27,11 @@ class EventTest {
   @InjectMocks
   private Event event;
 
-  private ObjectMapper mapper;
+  private JsonMapper mapper;
 
   @BeforeEach
   void beforeEach() {
-    mapper = JsonMapper.builder().build();
+    mapper = MapperHelper.build();
   }
 
   @Test

--- a/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
+++ b/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
@@ -25,6 +25,17 @@ public class MapperHelper {
    * @return The built mapper.
    */
   public static JsonMapper build() {
+    return construct().build();
+  }
+
+  /**
+   * Construct the JsonMapper without building it.
+   *
+   * Use this to customize the defaults before changing.
+   *
+   * @return The mapper builder.
+   */
+  public static JsonMapper.Builder construct() {
     return JsonMapper
     .builderWithJackson2Defaults()
     .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
@@ -36,8 +47,7 @@ public class MapperHelper {
       .withValueInclusion(JsonInclude.Include.NON_NULL)
       .withContentInclusion(JsonInclude.Include.NON_NULL)
     )
-    .findAndAddModules()
-    .build();
+    .findAndAddModules();
   }
 
 }

--- a/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
+++ b/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
@@ -1,0 +1,43 @@
+package org.folio.spring.test.helper;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Unit test helper for constructing the JsonMapper without going through Spring.
+ */
+public class MapperHelper {
+  
+  /**
+   * Prohibit construction on this helper utility.
+   */
+  private MapperHelper() {
+    // Should not do anything.
+  }
+
+  /**
+   * Build the JsonMapper.
+   *
+   * @return The built mapper.
+   */
+  public static JsonMapper build() {
+    return JsonMapper
+    .builderWithJackson2Defaults()
+    .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .configure(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES, true)
+    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+    .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true)
+    .changeDefaultPropertyInclusion(incl -> incl
+      .withValueInclusion(JsonInclude.Include.NON_NULL)
+      .withContentInclusion(JsonInclude.Include.NON_NULL)
+    )
+    .findAndAddModules()
+    .build();
+  }
+
+}

--- a/test/src/main/java/org/folio/spring/test/mock/MockMvcConstant.java
+++ b/test/src/main/java/org/folio/spring/test/mock/MockMvcConstant.java
@@ -3,6 +3,7 @@ package org.folio.spring.test.mock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.folio.spring.test.helper.MapperHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -10,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
@@ -295,8 +295,8 @@ public class MockMvcConstant {
     String responseAsJson = "";
 
     try {
-      ObjectMapper objectMapper = JsonMapper.builder().build();
-      responseAsJson = objectMapper.writeValueAsString(STRING_LIST);
+      final JsonMapper mapper = MapperHelper.build();
+      responseAsJson = mapper.writeValueAsString(STRING_LIST);
     } catch (JacksonException e) {
       logger.error("Initialization of static string list as JSON failed.", e);
     }

--- a/test/src/test/java/org/folio/spring/test/TestApplication.java
+++ b/test/src/test/java/org/folio/spring/test/TestApplication.java
@@ -1,0 +1,20 @@
+package org.folio.spring.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+@SpringBootApplication(scanBasePackages = "org.folio.spring.test")
+public class TestApplication extends SpringBootServletInitializer {
+
+  @Override
+  protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+    return application.sources(TestApplication.class);
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(TestApplication.class, args);
+  }
+
+}

--- a/test/src/test/java/org/folio/spring/test/helper/MapperHelperTest.java
+++ b/test/src/test/java/org/folio/spring/test/helper/MapperHelperTest.java
@@ -1,0 +1,38 @@
+package org.folio.spring.test.helper;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The helper class is for testing purpose, so only do basic existence tests.
+ */
+class MapperHelperTest {
+
+  @Test
+  void buildReturnsValidObjectTest() {
+    final JsonMapper mapper = MapperHelper.build();
+
+    assertNotNull(mapper);
+  }
+
+  @Test
+  void constructReturnsValidObjectTest() {
+    final JsonMapper.Builder builder = MapperHelper.construct();
+
+    assertNotNull(builder);
+  }
+
+  @Test
+  void constructReturnedBuilderBuildsTest() {
+    final JsonMapper.Builder builder = MapperHelper.construct();
+
+    assertNotNull(builder);
+
+    final JsonMapper mapper = builder.build();
+
+    assertNotNull(mapper);
+  }
+
+}


### PR DESCRIPTION
Further resolves [SPRNGCORE-18](https://folio-org.atlassian.net/browse/SPRNGCORE-18) .

Use `JsonMapper` directly instead of `ObjectMapper`.
  - Use **Jackson 2** as the default behavior.
  - Apply common default properties.
  - Ensure modules are auto-found just like with **Jackson 2**.

Address some of the problems reported by **SonarQube**.

Provide a `MapperHelper` in the unit tests in order to have a consistent way of instantiating `JsonMapper`.
  - This avoids having to add the excessive and complicated settings that are now needed due to the **Jackson 3** design.