### PR TITLE
SPRNGCORE-30: Add support for `folio.sql.schema` via the tenant module.

### DIFF
--- a/tenant/src/main/java/org/folio/spring/tenant/config/FolioConfig.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/config/FolioConfig.java
@@ -1,0 +1,58 @@
+package org.folio.spring.tenant.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provide tenant specific configuration.
+ */
+@Component
+@ConfigurationProperties("folio")
+public class FolioConfig {
+
+  private FolioSqlConfig sql = new FolioSqlConfig();
+
+  /**
+   * Get the SQL configuration.
+   *
+   * @return The SQL configuration.
+   */
+  public FolioSqlConfig getSql() {
+    return sql;
+  }
+
+  /**
+   * Set the SQL configuration.
+   *
+   * @param sql The SQL configuration to set.
+   */
+  public void setSql(FolioSqlConfig sql) {
+    this.sql = sql;
+  }
+
+  @ConfigurationProperties("folio.sql")
+  public class FolioSqlConfig {
+
+    private String schema;
+
+    /**
+     * Get the schema.
+     *
+     * @return The schema.
+     */
+    public String getSchema() {
+      return schema;
+    }
+
+    /**
+     * Set the schema.
+     *
+     * @param schema The schema to set.
+     */
+    public void setSchema(String schema) {
+      this.schema = schema;
+    }
+
+  }
+
+}

--- a/tenant/src/main/java/org/folio/spring/tenant/service/SchemaService.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/service/SchemaService.java
@@ -2,8 +2,8 @@ package org.folio.spring.tenant.service;
 
 import java.util.Locale;
 import java.util.regex.Pattern;
+import org.folio.spring.tenant.config.FolioConfig;
 import org.folio.spring.tenant.properties.BuildInfoProperties;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,16 +12,34 @@ public class SchemaService {
   // allow list of characters prevents SQL injection
   private static final Pattern SCHEMA_REGEXP = Pattern.compile("[a-z0-9_]+");
 
-  @Autowired
   private BuildInfoProperties buildInfoProperties;
 
+  private FolioConfig folioConfig;
+
+  /**
+   * Initialize class.
+   *
+   * @param buildInfoProperties
+   */
+  public SchemaService(BuildInfoProperties buildInfoProperties, FolioConfig folioConfig) {
+
+    this.buildInfoProperties = buildInfoProperties;
+    this.folioConfig = folioConfig;
+  }
+
   public String getSchema(String tenant) {
-    String schema = String.format("%s_%s", tenant, buildInfoProperties.getArtifact())
-        .replace("-", "_").toLowerCase(Locale.ROOT);
-    if (! SCHEMA_REGEXP.matcher(schema).matches()) {
+
+    final String schema = folioConfig.getSql().getSchema();
+
+    final String schemaName = (schema == null || schema.trim().isEmpty())
+      ? String.format("%s_%s", tenant, buildInfoProperties.getArtifact()).replace("-", "_").toLowerCase(Locale.ROOT)
+      : schema;
+
+    if (!SCHEMA_REGEXP.matcher(schemaName).matches()) {
       throw new IllegalArgumentException("Illegal character in schema name: " + schema);
     }
-    return schema;
+
+    return schemaName;
   }
 
 }

--- a/tenant/src/test/java/org/folio/spring/tenant/config/FolioConfigTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/config/FolioConfigTest.java
@@ -1,0 +1,49 @@
+package org.folio.spring.tenant.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.folio.spring.tenant.config.FolioConfig.FolioSqlConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FolioConfigTest {
+
+  private static final String SQL = "sql";
+
+  @InjectMocks
+  private FolioConfig folioConfig;
+
+  @Mock
+  private FolioSqlConfig folioSqlConfig;
+
+  /**
+   * Test the SQL getter.
+   */
+  @Test
+  void getSqlWorksTest() {
+
+    setField(folioConfig, SQL, folioSqlConfig);
+
+    assertEquals(folioConfig.getSql(), folioSqlConfig);
+  }
+
+  /**
+   * Test the SQL setter.
+   */
+  @Test
+  void setSqlWorksTest() {
+
+    setField(folioConfig, SQL, null);
+
+    folioConfig.setSql(folioSqlConfig);
+
+    assertEquals(getField(folioConfig, SQL), folioSqlConfig);
+  }
+
+}

--- a/tenant/src/test/java/org/folio/spring/tenant/config/FolioConfigTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/config/FolioConfigTest.java
@@ -30,7 +30,7 @@ class FolioConfigTest {
 
     setField(folioConfig, SQL, folioSqlConfig);
 
-    assertEquals(folioConfig.getSql(), folioSqlConfig);
+    assertEquals(folioSqlConfig, folioConfig.getSql());
   }
 
   /**
@@ -43,7 +43,7 @@ class FolioConfigTest {
 
     folioConfig.setSql(folioSqlConfig);
 
-    assertEquals(getField(folioConfig, SQL), folioSqlConfig);
+    assertEquals(folioSqlConfig, getField(folioConfig, SQL));
   }
 
 }

--- a/tenant/src/test/java/org/folio/spring/tenant/config/FolioSqlConfigTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/config/FolioSqlConfigTest.java
@@ -1,0 +1,45 @@
+package org.folio.spring.tenant.config;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FolioSqlConfigTest {
+
+  private static final String SCHEMA = "schema";
+
+  @InjectMocks
+  private FolioConfig folioConfig;
+
+  /**
+   * Test the schema getter.
+   */
+  @Test
+  void getSchemaWorksTest() {
+
+    setField(folioConfig.getSql(), SCHEMA, VALUE);
+
+    assertEquals(folioConfig.getSql().getSchema(), VALUE);
+  }
+
+  /**
+   * Test the schema setter.
+   */
+  @Test
+  void setSchemaWorksTest() {
+
+    setField(folioConfig.getSql(), SCHEMA, null);
+
+    folioConfig.getSql().setSchema(VALUE);
+
+    assertEquals(getField(folioConfig.getSql(), SCHEMA), VALUE);
+  }
+
+}

--- a/tenant/src/test/java/org/folio/spring/tenant/config/FolioSqlConfigTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/config/FolioSqlConfigTest.java
@@ -26,7 +26,7 @@ class FolioSqlConfigTest {
 
     setField(folioConfig.getSql(), SCHEMA, VALUE);
 
-    assertEquals(folioConfig.getSql().getSchema(), VALUE);
+    assertEquals(VALUE, folioConfig.getSql().getSchema());
   }
 
   /**
@@ -39,7 +39,7 @@ class FolioSqlConfigTest {
 
     folioConfig.getSql().setSchema(VALUE);
 
-    assertEquals(getField(folioConfig.getSql(), SCHEMA), VALUE);
+    assertEquals(VALUE, getField(folioConfig.getSql(), SCHEMA));
   }
 
 }

--- a/tenant/src/test/java/org/folio/spring/tenant/service/SchemaServiceTest.java
+++ b/tenant/src/test/java/org/folio/spring/tenant/service/SchemaServiceTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.folio.spring.tenant.config.FolioConfig;
 import org.folio.spring.tenant.properties.BuildInfoProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,7 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = SchemaService.class)
-@EnableConfigurationProperties(value = BuildInfoProperties.class)
+@EnableConfigurationProperties(value = { BuildInfoProperties.class, FolioConfig.class })
 @TestPropertySource(properties = "info.build.artifact=mod-Baz")
 class SchemaServiceTest {
 


### PR DESCRIPTION
Resolves [SPRNGCORE-30](https://folio-org.atlassian.net/browse/SPRNGCORE-30) .

The `DB_SCHEMA` can be specified to provide an explicitly named schema. Otherwise, the default (original) behavior is used.