### PR TITLE
SPRNGCORE-18: Handle Jackson changes and address SonarQube reported concerns.

### DIFF
--- a/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
+++ b/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
@@ -29,6 +29,7 @@ public class JacksonConfiguration {
       .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
       .configure(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES, true)
+      .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, true)
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true)
       .changeDefaultPropertyInclusion(incl -> incl

--- a/tenant/src/main/java/org/folio/spring/tenant/controller/TenantController.java
+++ b/tenant/src/main/java/org/folio/spring/tenant/controller/TenantController.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 import org.folio.spring.tenant.annotation.TenantHeader;
 import org.folio.spring.tenant.hibernate.HibernateSchemaService;
 import org.folio.spring.tenant.model.request.TenantAttributes;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,34 +23,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/_/tenant")
 public class TenantController {
 
-  @Autowired
   private HibernateSchemaService hibernateSchemaService;
+
+  /**
+   * Initializer.
+   *
+   * @param hibernateSchemaService The hibernateSchemaService instance.
+   */
+  public TenantController(HibernateSchemaService hibernateSchemaService) {
+
+    this.hibernateSchemaService = hibernateSchemaService;
+  }
 
   @PostMapping
   public ResponseEntity<String> create(
     @TenantHeader String tenant,
     @RequestBody @Validated TenantAttributes attributes,
-    @RequestHeader(value = "accept", required = false) String accept
+    @RequestHeader(required = false) String accept
   ) throws SQLException, IOException {
     if (unsupportedAccept(accept, MediaType.TEXT_PLAIN)) {
       return ResponseEntity.status(406).build();
     }
 
     hibernateSchemaService.createTenant(tenant);
-    return new ResponseEntity<String>("Success", CREATED);
+    return new ResponseEntity<>("Success", CREATED);
   }
 
   @DeleteMapping
   public ResponseEntity<Void> delete(
     @TenantHeader String tenant,
-    @RequestHeader(value = "accept", required = false) String accept
+    @RequestHeader(required = false) String accept
   ) throws SQLException {
     if (unsupportedAccept(accept, MediaType.TEXT_PLAIN)) {
       return ResponseEntity.status(406).build();
     }
 
     hibernateSchemaService.deleteTenant(tenant);
-    return new ResponseEntity<Void>(NO_CONTENT);
+    return new ResponseEntity<>(NO_CONTENT);
   }
 
 }

--- a/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
+++ b/test/src/main/java/org/folio/spring/test/helper/MapperHelper.java
@@ -41,6 +41,7 @@ public class MapperHelper {
     .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .configure(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES, true)
+    .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, true)
     .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
     .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true)
     .changeDefaultPropertyInclusion(incl -> incl

--- a/web/src/main/java/org/folio/spring/web/converter/ObjectPlainTextConverter.java
+++ b/web/src/main/java/org/folio/spring/web/converter/ObjectPlainTextConverter.java
@@ -16,25 +16,24 @@
 
 package org.folio.spring.web.converter;
 
+import static org.folio.spring.web.utility.RequestHeaderUtility.APP_JSON_PLUS;
+import static org.folio.spring.web.utility.RequestHeaderUtility.compatibleWith;
 import static org.springframework.http.MediaType.ALL;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
-import static org.folio.spring.web.utility.RequestHeaderUtility.APP_JSON_PLUS;
-import static org.folio.spring.web.utility.RequestHeaderUtility.compatibleWith;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageConverter;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.lang.Nullable;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 


### PR DESCRIPTION
Further resolves [SPRNGCORE-18](https://folio-org.atlassian.net/browse/SPRNGCORE-18), addressing things overlooked in previous upgrade effortss.

Explicitly define Jackson 2 behavior:
  - The `MapperFeature.DEFAULT_VIEW_INCLUSION` is `true` by default in **Jackson 2** but not in **Jackson 3**.

Remove unecessary code snippets:
  - The `@RequestHeader` has unnecessary `value = ""` annotations.
  - The `ResponseEntity<>` does not need arguments specified in the `return` lines.

Replace overlooked deprecated `@Nullable` use:
  - Switch to `org.jspecify.annotations.Nullable`.

Avoid using `@Autowired` on variable declarations and instead provide an initializer function.