### PR TITLE
SPRNGCORE-34: Ensure JsonMapper creates proper time stamps for Instant.

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -61,6 +61,11 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-mysql</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
+++ b/domain/src/main/java/org/folio/spring/domain/config/JacksonConfiguration.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,11 +14,13 @@ import org.springframework.context.annotation.Configuration;
 public class JacksonConfiguration {
 
   @Bean
-  public ObjectMapper objectMapper() {
+  ObjectMapper objectMapper() {
     return JsonMapper.builder()
       .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
       .enable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+      .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .addModule(new JavaTimeModule())
       .build();
   }
 }


### PR DESCRIPTION
Resolves [SPRNGCORE-34](https://folio-org.atlassian.net/browse/SPRNGCORE-34).

Bring in `jackson-datatype-jsr310` dependency.

Update the mapper instantiation.